### PR TITLE
Add supoprt for building Google Play release bundles from GH Actions

### DIFF
--- a/.github/workflows/build-google_play.yml
+++ b/.github/workflows/build-google_play.yml
@@ -1,0 +1,74 @@
+name: "[CI/CD] Build Google Play release bundle"
+
+on:
+  workflow_call:
+    inputs:
+      github_run_number:
+        required: true
+        type: string
+    secrets:
+      CR_PAT:
+        required: true
+      GH_TOKEN:
+        required: true
+      MATCH_DEPLOY_KEY:
+        required: true
+      MATCH_PASSWORD:
+        required: true
+      MATCH_REPO:
+        required: true
+      GH_PACKAGE_REGISTRY_PAT:
+        required: true
+
+
+jobs:
+  ## --- GET GAME METADATA ---
+  gather_game_data:
+    name: Gather game metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v2
+
+      - name: Checkout private actions
+        uses: actions/checkout@v2                     
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          path: ./actions
+
+      - id: metadata
+        name: Execute metadata action
+        uses: ./actions/.github/actions/getmetadata
+    outputs:
+      game_name: ${{ steps.metadata.outputs.game_name }}
+      deploy_msg: ${{ steps.metadata.outputs.deploy_msg }}  
+
+  ## --- Generate Google Play project for game ---
+  generate_googleplay:
+    name: Generate Google Play project
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [gather_game_data]
+    container:
+      image: ghcr.io/frvraps/fst@sha256:460d5348a9294ab18e907fa8480971bc765036981ca8337079988e36eaabde99
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+    steps:
+      - name: Checkout private actions
+        uses: actions/checkout@v2                     
+        with:
+          repository: frvraps/frvr-gh-workflows 
+          ref: feature/CH-464-add-support-for-GH-Actions-release-build
+          token: ${{ secrets.GH_TOKEN }}
+          path: ./actions
+
+      - id: generategoogleplay
+        name: '[FRVR Action] Generate Google Play Project release bundle'
+        uses: ./actions/.github/actions/generategoogleplay
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_PACKAGE_REGISTRY_PAT: ${{ secrets.GH_PACKAGE_REGISTRY_PAT }}


### PR DESCRIPTION
# Type of PR
[ ] Bug Fix
[X] New Feature
[ ] Other

# References
CH-464

# What problem does this PR address
We want to automate-away the (rather error-prone) release build process, having a _Single Source of Truth™_

# How does this PR addresses the problem
By having the build happening on a clean install of the build environment and centralised into a Github action, we go one step further, just requiring the upload of the resulting AAB into Google Play.

# Implementation notes
For now, this assumes always the develop versions of both tools and internal. Hopefully, we can expand from this very soon, allowing to specify the custom versions of both.

This solution was originally derived from the work done for iOS, which has much more complex requirements. Some extra steps are usually required for it, that are not required for Android platforms. Hopefully, you can point me to aspects not needed here!

# Platforms/Channels
This addresses Google Play only, for now.

# What was tested
Builds of Darts resulted in valid AAB files.
https://github.com/frvraps/game-darts/actions/runs/2005273646

# How to validate current changes
Generate Darts builds from its Action panel.
