### PR TITLE
XS-452: Reactivate web UI tests

### DIFF
--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -131,48 +131,48 @@ jobs:
     outputs:
       deploy_url: ${{ steps.deployweb.outputs.deploy_url }}
 
-  ## --- Run GUI Automated tests on WEB ---
-  # run_web_gui_automated_tests:
-  #   name: GUI automated tests on web
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 10
-  #   needs: [gather_game_data, build_web, deploy_web]
-  #   defaults:
-  #     run:
-  #       working-directory: /app/tests
-  #   env:
-  #     TEST_URL: ${{ needs.deploy_web.outputs.deploy_url }}
-  #     HEADLESS: true
-  #     TESTS_PATH: ${{ github.workspace }}/game/tests
-  #   container:
-  #     image: ${{ inputs.automation_image }}:latest
-  #     credentials:
-  #       username: ${{ github.repository_owner }}
-  #       password: ${{ secrets.CR_PAT }}
-  #   steps:
-  #     - name: Checkout the repo
-  #       uses: actions/checkout@v2
-  #       with:
-  #         path: ${{ github.workspace }}/game
+  # --- Run GUI Automated tests on WEB ---
+  run_web_gui_automated_tests:
+    name: GUI automated tests on web
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [gather_game_data, build_web, deploy_web]
+    defaults:
+      run:
+        working-directory: /app/tests
+    env:
+      TEST_URL: ${{ needs.deploy_web.outputs.deploy_url }}
+      HEADLESS: true
+      TESTS_PATH: ${{ github.workspace }}/game/tests
+    container:
+      image: ${{ inputs.automation_image }}:latest
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/game
       
-  #     - name: Install sudo
-  #       run: |
-  #         apt-get update && apt-get -y install sudo
+      - name: Install sudo
+        run: |
+          apt-get update && apt-get -y install sudo
 
-  #     - name: Checkout private actions
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: frvraps/frvr-gh-workflows
-  #         token: ${{ secrets.GH_TOKEN }}
-  #         ref: main
-  #         path: ./actions
+      - name: Checkout private actions
+        uses: actions/checkout@v2
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: main
+          path: ./actions
 
-  #     - name: '[FRVR Action] Web GUI tests'
-  #       uses: ./actions/.github/actions/runwebguitests
-  #       with:
-  #         game_name: ${{ needs.gather_game_data.outputs.game_name }}
-  #         GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  #       env:
-  #         TEST_URL: ${{ needs.deploy_web.outputs.deploy_url }}
-  #         HEADLESS: true
-  #         TESTS_PATH: ${{ github.workspace }}/game/tests
+      - name: '[FRVR Action] Web GUI tests'
+        uses: ./actions/.github/actions/runwebguitests
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        env:
+          TEST_URL: ${{ needs.deploy_web.outputs.deploy_url }}
+          HEADLESS: true
+          TESTS_PATH: ${{ github.workspace }}/game/tests


### PR DESCRIPTION
# Type of PR
[ X ] Bug Fix
[ ] New Feature
[ ] Other

# References
[XS-452](https://frvr.atlassian.net/browse/XS-452)
frvr-gh-workflow [related PR](https://github.com/frvraps/frvr-gh-workflows/pull/9)

# What problem does this PR address
Web GUI have been deactivated for a while on the default CI/CD workflow, due to externalized action being broken.

# How does this PR addresses the problem
Reactivates the web GUI tests.

# Implementation notes
N/A

# Platforms/Channels
Web

# What was tested
Multiple local and github runs (as in [related PR](https://github.com/frvraps/frvr-gh-workflows/pull/9))

# How to validate current changes
Again, a bit tricky. Let me know if you want to.