### PR TITLE
feature/XS-465 add samsung galaxy pipeline

### DIFF
--- a/.github/workflows/pipeline-samsung-galaxy.yml
+++ b/.github/workflows/pipeline-samsung-galaxy.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v2                     
         with:
           repository: frvraps/frvr-gh-workflows 
-          ref: XS-465
+          ref: main
           token: ${{ secrets.GH_TOKEN }}
           path: ./actions
 
@@ -94,6 +94,8 @@ jobs:
     outputs:
       filename: ${{ steps.buildsamsunggalaxy.outputs.filename }}
       build_json: ${{ steps.buildsamsunggalaxy.outputs.build_json }}
+      binary_url: ${{ steps.buildsamsunggalaxy.outputs.binary_url }}
+
 
   ## --- Deploy Samsung Galaxy binary ---
   deploy_samsung_galaxy:
@@ -113,7 +115,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: XS-465
+          ref: main
           path: ./actions
 
       - id: deploy_samsung_galaxy
@@ -223,7 +225,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: XS-465
+          ref: main
           path: ./actions
 
       - name: '[FRVR Action] Slack Notify from Pipeline'

--- a/.github/workflows/pipeline-samsung-galaxy.yml
+++ b/.github/workflows/pipeline-samsung-galaxy.yml
@@ -77,13 +77,13 @@ jobs:
         uses: actions/checkout@v2                     
         with:
           repository: frvraps/frvr-gh-workflows 
-          ref: feature/CH-464-add-support-for-GH-Actions-release-build
+          ref: XS-465
           token: ${{ secrets.GH_TOKEN }}
           path: ./actions
 
-      - id: generatesamsunggalaxy
+      - id: buildsamsunggalaxy
         name: '[FRVR Action] Generate Samsung Galaxy  Project release bundle'
-        uses: ./actions/.github/actions/generatesamsunggalaxy
+        uses: ./actions/.github/actions/buildsamsunggalaxy
         with:
           game_name: ${{ needs.gather_game_data.outputs.game_name }}
           game_branch: ${{ github.event.inputs.game_branch }}
@@ -92,7 +92,7 @@ jobs:
           GCS_MASTERDOC_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_MASTERDOC_SERVICE_ACCOUNT_KEY }}
           GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
     outputs:
-      filename: ${{ steps.generatesamsunggalaxy.outputs.filename }}
+      filename: ${{ steps.buildsamsunggalaxy.outputs.filename }}
       build_json: ${{ steps.buildsamsunggalaxy.outputs.build_json }}
 
   ## --- Deploy Samsung Galaxy binary ---
@@ -137,48 +137,46 @@ jobs:
       deploy_url: ${{ steps.deploy_samsung_galaxy.outputs.deploy_url }}
 
   ## --- Create the Asana task ---
-  create_asana_task:
-    name: Create Asana task
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: github.repository == 'never_run_this'
-    needs: [gather_game_data, build_samsung_galaxy, deploy_samsung_galaxy]
-    steps:
-      - name: Checkout game repo
-        uses: actions/checkout@v3
-        with:
-          path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
-          ref: ${{ github.event.inputs.game_branch }}
+  # create_asana_task:
+  #   name: Create Asana task
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   needs: [gather_game_data, build_samsung_galaxy, deploy_samsung_galaxy]
+  #   steps:
+  #     - name: Checkout game repo
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
+  #         ref: ${{ github.event.inputs.game_branch }}
 
-      - name: Checkout private actions
-        uses: actions/checkout@v3
-        with:
-          repository: frvraps/frvr-gh-workflows
-          token: ${{ secrets.GH_TOKEN }}
-          ref: main
-          path: ./actions
+  #     - name: Checkout private actions
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: frvraps/frvr-gh-workflows
+  #         token: ${{ secrets.GH_TOKEN }}
+  #         ref: main
+  #         path: ./actions
 
-      - id: asanatask
-        name: '[FRVR Action] Create Asana task'
-        uses: ./actions/.github/actions/createasanaticket
-        with:
-          game_name: ${{ needs.gather_game_data.outputs.game_name }}
-          game_branch: ${{ github.event.inputs.game_branch }}
-          deployed_filename: ${{ needs.build__samsung_galaxy.outputs.filename }}
-          frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
-          ticket_message: 'Play Link: ${{ needs.deploy__samsung_galaxy.outputs.deploy_url }}'
-          channel: 'SAmsung Galaxy Store'
-          asana_check: ${{ github.event.inputs.asana_check }}
-          ASANA_PAT: ${{ secrets.ASANA_PAT }}
-    outputs:
-      task_url: ${{ steps.asanatask.outputs.task_url }}
+  #     - id: asanatask
+  #       name: '[FRVR Action] Create Asana task'
+  #       uses: ./actions/.github/actions/createasanaticket
+  #       with:
+  #         game_name: ${{ needs.gather_game_data.outputs.game_name }}
+  #         game_branch: ${{ github.event.inputs.game_branch }}
+  #         deployed_filename: ${{ needs.build__samsung_galaxy.outputs.filename }}
+  #         frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+  #         ticket_message: 'Play Link: ${{ needs.deploy__samsung_galaxy.outputs.deploy_url }}'
+  #         channel: 'Samsung Galaxy Store'
+  #         asana_check: ${{ github.event.inputs.asana_check }}
+  #         ASANA_PAT: ${{ secrets.ASANA_PAT }}
+  #   outputs:
+  #     task_url: ${{ steps.asanatask.outputs.task_url }}
 
   ## --- Update Masterdoc ---
   update_master_doc:
     name: Update Masterdoc
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.repository == 'never_run_this'
     needs: [gather_game_data, build_samsung_galaxy, deploy_samsung_galaxy]
     steps:
       - name: Checkout game repo
@@ -202,7 +200,7 @@ jobs:
           game_branch: ${{ github.event.inputs.game_branch }}
           frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
           build_json_filename: ${{ needs.build_samsung_galaxy.outputs.build_json }}
-          channel: 'instant'
+          channel: 'samsung_galaxystore'
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
           GCS_MASTERDOC_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_MASTERDOC_SERVICE_ACCOUNT_KEY }}
@@ -212,8 +210,7 @@ jobs:
     name: Notify slack
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.repository == 'never_run_this'
-    needs: [gather_game_data, build_samsung_galaxy, deploy_samsung_galaxy, create_asana_task]
+    needs: [gather_game_data, build_samsung_galaxy, deploy_samsung_galaxy]
     steps:
       - name: Checkout game repo
         uses: actions/checkout@v3
@@ -226,7 +223,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: main
+          ref: XS-465
           path: ./actions
 
       - name: '[FRVR Action] Slack Notify from Pipeline'
@@ -235,6 +232,6 @@ jobs:
           game_name: ${{ needs.gather_game_data.outputs.game_name }}
           game_branch: ${{ github.event.inputs.game_branch }}
           frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
-          channel: 'instant'
-          task_url: ${{ needs.create_asana_task.outputs.task_url }}
+          channel: 'samsung_galaxystore'
+          task_url: ''
           deploy_url: ${{ needs.deploy_samsung_galaxy.outputs.deploy_url }}

--- a/.github/workflows/pipeline-samsung-galaxy.yml
+++ b/.github/workflows/pipeline-samsung-galaxy.yml
@@ -1,0 +1,240 @@
+name: "[Pipeline] Build and deploy Samsung Galaxy Store "
+
+on:
+  workflow_call:
+    inputs:
+      game_branch:
+        required: true
+        type: string
+      frvr_tools_branch:
+        required: true
+        type: string
+      asana_check:
+        required: true
+        type: string
+      comment:
+        required: true
+        type: string
+    secrets:
+      CR_PAT:
+        required: true
+      GH_TOKEN:
+        required: true
+      GCS_PROJECT:
+        required: true
+      AUTOMATED_RELEASE_CREDENTIALS:
+        required: true
+      GH_PACKAGE_REGISTRY_PAT:
+        required: true
+      GCS_DEVOPS_BINARY_BUCKET_KEY:
+        required: true
+      GCS_SA_KEY:
+        required: true
+      ASANA_PAT:
+        required: true
+      GCS_MASTERDOC_SERVICE_ACCOUNT_KEY:
+        required: true
+
+jobs:
+  ## --- GET GAME METADATA ---
+  gather_game_data:
+    name: Gather game metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.game_branch }}
+
+      - name: Checkout private actions
+        uses: actions/checkout@v3
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: main
+          path: ./actions
+
+      - name: '[FRVR Action] Execute metadata action'
+        id: metadata
+        uses: ./actions/.github/actions/getmetadata
+    outputs:
+      game_name: ${{ steps.metadata.outputs.game_name }}
+
+  ## --- Build Samsung Galaxy ---
+  build_samsung_galaxy:
+    name: Build Samsung Galaxy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [gather_game_data]
+    container:
+      image: ghcr.io/frvraps/fst:2.4.7
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+    steps:
+      - name: Checkout private actions
+        uses: actions/checkout@v2                     
+        with:
+          repository: frvraps/frvr-gh-workflows 
+          ref: feature/CH-464-add-support-for-GH-Actions-release-build
+          token: ${{ secrets.GH_TOKEN }}
+          path: ./actions
+
+      - id: generatesamsunggalaxy
+        name: '[FRVR Action] Generate Samsung Galaxy  Project release bundle'
+        uses: ./actions/.github/actions/generatesamsunggalaxy
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          game_branch: ${{ github.event.inputs.game_branch }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_PACKAGE_REGISTRY_PAT: ${{ secrets.GH_PACKAGE_REGISTRY_PAT }}
+          GCS_MASTERDOC_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_MASTERDOC_SERVICE_ACCOUNT_KEY }}
+          GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
+    outputs:
+      filename: ${{ steps.generatesamsunggalaxy.outputs.filename }}
+      build_json: ${{ steps.buildsamsunggalaxy.outputs.build_json }}
+
+  ## --- Deploy Samsung Galaxy binary ---
+  deploy_samsung_galaxy:
+    name: Deploy Samsung Galaxy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [gather_game_data, build_samsung_galaxy]
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
+          ref: ${{ github.event.inputs.game_branch }}
+
+      - name: Checkout private actions
+        uses: actions/checkout@v3
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: XS-465
+          path: ./actions
+
+      - id: deploy_samsung_galaxy
+        name: '[FRVR Action] Deploy Samsung Galaxy'
+        uses: ./actions/.github/actions/deploysamsunggalaxy
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          game_branch: ${{ github.event.inputs.game_branch }}
+          frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+          build_identifier: ${{ needs.build_samsung_galaxy.outputs.filename }}
+          comment: '[GAME] ${{ github.event.inputs.game_branch }}
+          [ENGINE] ${{ github.event.inputs.frvr_tools_branch }}
+          [USER] ${{ github.actor }}
+          [COMMENT] ${{ github.event.inputs.comment }}'
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          AUTOMATED_RELEASE_CREDENTIALS : ${{ secrets.AUTOMATED_RELEASE_CREDENTIALS }}
+          GH_PACKAGE_REGISTRY_PAT: ${{ secrets.GH_PACKAGE_REGISTRY_PAT }}
+          GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
+          GCS_SA_KEY: ${{ secrets.GCS_SA_KEY }}
+    outputs:
+      deploy_url: ${{ steps.deploy_samsung_galaxy.outputs.deploy_url }}
+
+  ## --- Create the Asana task ---
+  create_asana_task:
+    name: Create Asana task
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.repository == 'never_run_this'
+    needs: [gather_game_data, build_samsung_galaxy, deploy_samsung_galaxy]
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
+          ref: ${{ github.event.inputs.game_branch }}
+
+      - name: Checkout private actions
+        uses: actions/checkout@v3
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: main
+          path: ./actions
+
+      - id: asanatask
+        name: '[FRVR Action] Create Asana task'
+        uses: ./actions/.github/actions/createasanaticket
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          game_branch: ${{ github.event.inputs.game_branch }}
+          deployed_filename: ${{ needs.build__samsung_galaxy.outputs.filename }}
+          frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+          ticket_message: 'Play Link: ${{ needs.deploy__samsung_galaxy.outputs.deploy_url }}'
+          channel: 'SAmsung Galaxy Store'
+          asana_check: ${{ github.event.inputs.asana_check }}
+          ASANA_PAT: ${{ secrets.ASANA_PAT }}
+    outputs:
+      task_url: ${{ steps.asanatask.outputs.task_url }}
+
+  ## --- Update Masterdoc ---
+  update_master_doc:
+    name: Update Masterdoc
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.repository == 'never_run_this'
+    needs: [gather_game_data, build_samsung_galaxy, deploy_samsung_galaxy]
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
+          ref: ${{ github.event.inputs.game_branch }}
+
+      - name: Checkout private actions
+        uses: actions/checkout@v3
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: main
+          path: ./actions
+
+      - name: '[FRVR Action] Update Masterdoc'
+        uses: ./actions/.github/actions/updatemasterdoc
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          game_branch: ${{ github.event.inputs.game_branch }}
+          frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+          build_json_filename: ${{ needs.build_samsung_galaxy.outputs.build_json }}
+          channel: 'instant'
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
+          GCS_MASTERDOC_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_MASTERDOC_SERVICE_ACCOUNT_KEY }}
+
+  ## --- Notify slack ---
+  notify_slack:
+    name: Notify slack
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.repository == 'never_run_this'
+    needs: [gather_game_data, build_samsung_galaxy, deploy_samsung_galaxy, create_asana_task]
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
+          ref: ${{ github.event.inputs.game_branch }}
+
+      - name: Checkout private actions
+        uses: actions/checkout@v3
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: main
+          path: ./actions
+
+      - name: '[FRVR Action] Slack Notify from Pipeline'
+        uses: ./actions/.github/actions/slacknotifypipeline
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          game_branch: ${{ github.event.inputs.game_branch }}
+          frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+          channel: 'instant'
+          task_url: ${{ needs.create_asana_task.outputs.task_url }}
+          deploy_url: ${{ needs.deploy_samsung_galaxy.outputs.deploy_url }}


### PR DESCRIPTION
# Type of PR
[ ] Bug Fix
[ X ] New Feature
[ ] Other

# References
[XS-465](https://frvr.atlassian.net/browse/XS-465) based on work done in [CH-464](https://frvr.atlassian.net/browse/CH-464) ([frvr-gh-workflows-pub](https://github.com/frvraps/frvr-gh-workflows-pub/tree/feature/CH-464-add-support-for-GH-Actions-release-build), [frvr-gh-workflows](https://github.com/frvraps/frvr-gh-workflows/tree/feature/CH-464-add-support-for-GH-Actions-release-build), [drag-race](https://github.com/frvraps/game-dragrace/tree/feature/CH-464-add-support-for-GH-Actions-release-build) and [frvr-automated-release-tools](https://github.com/frvraps/frvr-automated-release-tools/pull/16))

# What problem does this PR address
Not having an automated process for Samsung Galaxy build+deploys.

# How does this PR addresses the problem
Similar to the existing QA Pipelines for web, sip and fb instant, this PR introduces the respective pipeline for Samsung Galaxy.

# Implementation notes
- `fsx deploy` for samsung galaxy still has some tech debt that needs to be tackle, namely, the fact that calls to `contentUpdate` (in Samsung Galaxy dev api), which whilst working properly, are returning non expected results, which makes it difficult to validate if the call was entirely successful.
- Asana tasks are not being created due to ongoing ClickUp adoption (and related discussion...)

# Platforms/Channels
Samsung Galaxy Store

# What was tested
Lots of tests on GH Actions, latest of which [here](https://github.com/frvraps/game-dragrace/runs/8271036555?check_suite_focus=true)
