### PR TITLE
XS-467: Add google play pipeline

### DIFF
--- a/.github/workflows/pipeline-google_play.yml
+++ b/.github/workflows/pipeline-google_play.yml
@@ -211,35 +211,36 @@ jobs:
   #         GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
   #         GCS_MASTERDOC_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_MASTERDOC_SERVICE_ACCOUNT_KEY }}
 
-  # ## --- Notify slack ---
-  # notify_slack:
-  #   name: Notify slack
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 10
-  #   needs: [gather_game_data, build_google_play, deploy_google_play]
-  #   steps:
-  #     - name: Checkout game repo
-  #       uses: actions/checkout@v3
-  #       with:
-  #         path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
-  #         ref: ${{ github.event.inputs.game_branch }}
+  ## --- Notify slack ---
+  notify_slack:
+    name: Notify slack
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [gather_game_data, build_google_play]
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
+          ref: ${{ github.event.inputs.game_branch }}
 
-  #     - name: Checkout private actions
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: frvraps/frvr-gh-workflows
-  #         token: ${{ secrets.GH_TOKEN }}
-  #         ref: main
-  #         path: ./actions
+      - name: Checkout private actions
+        uses: actions/checkout@v3
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: main
+          path: ./actions
 
-  #     - name: '[FRVR Action] Slack Notify from Pipeline'
-  #       uses: ./actions/.github/actions/slacknotifypipeline
-  #       with:
-  #         game_name: ${{ needs.gather_game_data.outputs.game_name }}
-  #         game_branch: ${{ github.event.inputs.game_branch }}
-  #         frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
-  #         channel: 'google_play'
-  #         task_url: ''
-  #         deploy_url: ''
-  #         binary_url: ${{ needs.build_google_play.outputs.binary_url }}
+      - name: '[FRVR Action] Slack Notify from Pipeline'
+        uses: ./actions/.github/actions/slacknotifypipeline
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          game_branch: ${{ github.event.inputs.game_branch }}
+          frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+          channel: 'google_play'
+          task_url: ''
+          deploy_url: ''
+          binary_url: ${{ needs.build_google_play.outputs.binary_url }}
+          note: "Automated deploy not available yet. Please deploy manually."
 

--- a/.github/workflows/pipeline-google_play.yml
+++ b/.github/workflows/pipeline-google_play.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: XS-467_google_play
+          ref: main
           path: ./actions
 
       - name: '[FRVR Action] Execute metadata action'
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v2                     
         with:
           repository: frvraps/frvr-gh-workflows 
-          ref: XS-467_google_play
+          ref: main
           token: ${{ secrets.GH_TOKEN }}
           path: ./actions
 

--- a/.github/workflows/pipeline-google_play.yml
+++ b/.github/workflows/pipeline-google_play.yml
@@ -1,0 +1,245 @@
+name: "[Pipeline] Build and deploy Google Play Store"
+
+on:
+  workflow_call:
+    inputs:
+      game_branch:
+        required: true
+        type: string
+      frvr_tools_branch:
+        required: true
+        type: string
+      asana_check:
+        required: true
+        type: string
+      comment:
+        required: true
+        type: string
+    secrets:
+      CR_PAT:
+        required: true
+      GH_TOKEN:
+        required: true
+      GCS_PROJECT:
+        required: true
+      AUTOMATED_RELEASE_CREDENTIALS:
+        required: true
+      GH_PACKAGE_REGISTRY_PAT:
+        required: true
+      GCS_DEVOPS_BINARY_BUCKET_KEY:
+        required: true
+      GCS_SA_KEY:
+        required: true
+      ASANA_PAT:
+        required: true
+      GCS_MASTERDOC_SERVICE_ACCOUNT_KEY:
+        required: true
+
+jobs:
+  ## --- GET GAME METADATA ---
+  gather_game_data:
+    name: Gather game metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.game_branch }}
+
+      - name: Checkout private actions
+        uses: actions/checkout@v3
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: XS-467_google_play
+          path: ./actions
+
+      - name: '[FRVR Action] Execute metadata action'
+        id: metadata
+        uses: ./actions/.github/actions/getmetadata
+        with:
+          channel: 'google_play'
+          frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+    outputs:
+      game_name: ${{ steps.metadata.outputs.game_name }}
+      fst_version: ${{ steps.metadata.outputs.fst_version }}
+
+  ## --- Build Google Play ---
+  build_google_play:
+    name: Build Google Play
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [gather_game_data]
+    container:
+      image: ghcr.io/frvraps/fst:${{ needs.gather_game_data.outputs.fst_version }}
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+    steps:
+      - name: Checkout private actions
+        uses: actions/checkout@v2                     
+        with:
+          repository: frvraps/frvr-gh-workflows 
+          ref: XS-467_google_play
+          token: ${{ secrets.GH_TOKEN }}
+          path: ./actions
+
+      - id: buildgoogleplay
+        name: '[FRVR Action] Generate Google Play Project release bundle'
+        uses: ./actions/.github/actions/buildgoogleplay
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          game_branch: ${{ github.event.inputs.game_branch }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_PACKAGE_REGISTRY_PAT: ${{ secrets.GH_PACKAGE_REGISTRY_PAT }}
+          GCS_MASTERDOC_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_MASTERDOC_SERVICE_ACCOUNT_KEY }}
+          GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
+    outputs:
+      filename: ${{ steps.buildgoogleplay.outputs.filename }}
+      build_json: ${{ steps.buildgoogleplay.outputs.build_json }}
+      binary_url: ${{ steps.buildgoogleplay.outputs.binary_url }}
+
+
+  # ## --- Deploy Google Play binary ---
+  # deploy_google_play:
+  #   name: Deploy Google Play
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   needs: [gather_game_data, build_google_play]
+  #   steps:
+  #     - name: Checkout game repo
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
+  #         ref: ${{ github.event.inputs.game_branch }}
+
+  #     - name: Checkout private actions
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: frvraps/frvr-gh-workflows
+  #         token: ${{ secrets.GH_TOKEN }}
+  #         ref: main
+  #         path: ./actions
+
+  #     - id: deploy_google_play
+  #       name: '[FRVR Action] Deploy Google Play'
+  #       uses: ./actions/.github/actions/deploygoogleplay
+  #       with:
+  #         game_name: ${{ needs.gather_game_data.outputs.game_name }}
+  #         game_branch: ${{ github.event.inputs.game_branch }}
+  #         frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+  #         build_identifier: ${{ needs.build_google_play.outputs.filename }}
+  #         comment: '[GAME] ${{ github.event.inputs.game_branch }}
+  #         [ENGINE] ${{ github.event.inputs.frvr_tools_branch }}
+  #         [USER] ${{ github.actor }}
+  #         [COMMENT] ${{ github.event.inputs.comment }}'
+  #         GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  #         AUTOMATED_RELEASE_CREDENTIALS : ${{ secrets.AUTOMATED_RELEASE_CREDENTIALS }}
+  #         GH_PACKAGE_REGISTRY_PAT: ${{ secrets.GH_PACKAGE_REGISTRY_PAT }}
+  #         GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
+  #         GCS_SA_KEY: ${{ secrets.GCS_SA_KEY }}
+  #   outputs:
+  #     deploy_url: ${{ steps.deploy_google_play.outputs.deploy_url }}
+
+  ## --- Create the Asana task ---
+  # create_asana_task:
+  #   name: Create Asana task
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   needs: [gather_game_data, build_google_play, deploy_google_play]
+  #   steps:
+  #     - name: Checkout game repo
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
+  #         ref: ${{ github.event.inputs.game_branch }}
+
+  #     - name: Checkout private actions
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: frvraps/frvr-gh-workflows
+  #         token: ${{ secrets.GH_TOKEN }}
+  #         ref: main
+  #         path: ./actions
+
+  #     - id: asanatask
+  #       name: '[FRVR Action] Create Asana task'
+  #       uses: ./actions/.github/actions/createasanaticket
+  #       with:
+  #         game_name: ${{ needs.gather_game_data.outputs.game_name }}
+  #         game_branch: ${{ github.event.inputs.game_branch }}
+  #         deployed_filename: ${{ needs.build_google_play.outputs.filename }}
+  #         frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+  #         ticket_message: 'Play Link: ${{ needs.deploy_google_play.outputs.deploy_url }}'
+  #         channel: 'Google Play Store'
+  #         asana_check: ${{ github.event.inputs.asana_check }}
+  #         ASANA_PAT: ${{ secrets.ASANA_PAT }}
+  #   outputs:
+  #     task_url: ${{ steps.asanatask.outputs.task_url }}
+
+  # ## --- Update Masterdoc ---
+  # update_master_doc:
+  #   name: Update Masterdoc
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   needs: [gather_game_data, build_google_play, deploy_google_play]
+  #   steps:
+  #     - name: Checkout game repo
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
+  #         ref: ${{ github.event.inputs.game_branch }}
+
+  #     - name: Checkout private actions
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: frvraps/frvr-gh-workflows
+  #         token: ${{ secrets.GH_TOKEN }}
+  #         ref: main
+  #         path: ./actions
+
+  #     - name: '[FRVR Action] Update Masterdoc'
+  #       uses: ./actions/.github/actions/updatemasterdoc
+  #       with:
+  #         game_name: ${{ needs.gather_game_data.outputs.game_name }}
+  #         game_branch: ${{ github.event.inputs.game_branch }}
+  #         frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+  #         build_json_filename: ${{ needs.build_google_play.outputs.build_json }}
+  #         channel: 'google_play'
+  #         GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  #         GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
+  #         GCS_MASTERDOC_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_MASTERDOC_SERVICE_ACCOUNT_KEY }}
+
+  # ## --- Notify slack ---
+  # notify_slack:
+  #   name: Notify slack
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   needs: [gather_game_data, build_google_play, deploy_google_play]
+  #   steps:
+  #     - name: Checkout game repo
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
+  #         ref: ${{ github.event.inputs.game_branch }}
+
+  #     - name: Checkout private actions
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: frvraps/frvr-gh-workflows
+  #         token: ${{ secrets.GH_TOKEN }}
+  #         ref: main
+  #         path: ./actions
+
+  #     - name: '[FRVR Action] Slack Notify from Pipeline'
+  #       uses: ./actions/.github/actions/slacknotifypipeline
+  #       with:
+  #         game_name: ${{ needs.gather_game_data.outputs.game_name }}
+  #         game_branch: ${{ github.event.inputs.game_branch }}
+  #         frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
+  #         channel: 'google_play'
+  #         task_url: ''
+  #         deploy_url: ''
+  #         binary_url: ${{ needs.build_google_play.outputs.binary_url }}
+


### PR DESCRIPTION
# Type of PR
[ ] Bug Fix
[ X ] New Feature
[ ] Other

# References
[XS-467](https://frvr.atlassian.net/browse/XS-467) based on work done in [CH-464](https://frvr.atlassian.net/browse/CH-464) ([frvr-gh-workflows-pub](https://github.com/frvraps/frvr-gh-workflows-pub/tree/feature/CH-464-add-support-for-GH-Actions-release-build), [frvr-gh-workflows](https://github.com/frvraps/frvr-gh-workflows/tree/feature/CH-464-add-support-for-GH-Actions-release-build), [drag-race](https://github.com/frvraps/game-dragrace/tree/feature/CH-464-add-support-for-GH-Actions-release-build) and [frvr-automated-release-tools](https://github.com/frvraps/frvr-automated-release-tools/pull/16))
Companion PR: [frvr-gh-workflows](https://github.com/frvraps/frvr-gh-workflows/pull/13)

# What problem does this PR address
Not having an automated process for Google Play builds.

# How does this PR addresses the problem
Similar to the existing QA Pipelines for web, sip and fb instant, this PR introduces the respective pipeline for Google Play.

# Implementation notes
- Asana tasks are not being created due to ongoing ClickUp adoption (and related discussion...)
- Uses an extra note on the slack notif

# Platforms/Channels
Google Play

# What was tested
Lots of tests on GH Actions.
