### PR TITLE
XS-487: remove asana from QA pipelines

### DIFF
--- a/.github/workflows/pipeline-fb-instant.yml
+++ b/.github/workflows/pipeline-fb-instant.yml
@@ -194,6 +194,6 @@ jobs:
           game_branch: ${{ github.event.inputs.game_branch }}
           frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
           channel: 'instant'
-          task_url: 'none'
+          task_url: ''
           deploy_url: ${{ needs.deploy_facebook_instant.outputs.deploy_url }}
           binary_url: ${{ needs.build_facebook_instant.outputs.binary_url }}

--- a/.github/workflows/pipeline-fb-instant.yml
+++ b/.github/workflows/pipeline-fb-instant.yml
@@ -9,9 +9,6 @@ on:
       frvr_tools_branch:
         required: true
         type: string
-      asana_check:
-        required: true
-        type: string
       comment:
         required: true
         type: string
@@ -29,8 +26,6 @@ on:
       GCS_DEVOPS_BINARY_BUCKET_KEY:
         required: true
       GCS_SA_KEY:
-        required: true
-      ASANA_PAT:
         required: true
       GCS_MASTERDOC_SERVICE_ACCOUNT_KEY:
         required: true
@@ -138,42 +133,6 @@ jobs:
     outputs:
       deploy_url: ${{ steps.deploy_facebook.outputs.deploy_url }}
 
-  ## --- Create the Asana task ---
-  create_asana_task:
-    name: Create Asana task
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: [gather_game_data, build_facebook_instant, deploy_facebook_instant]
-    steps:
-      - name: Checkout game repo
-        uses: actions/checkout@v3
-        with:
-          path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
-          ref: ${{ github.event.inputs.game_branch }}
-
-      - name: Checkout private actions
-        uses: actions/checkout@v3
-        with:
-          repository: frvraps/frvr-gh-workflows
-          token: ${{ secrets.GH_TOKEN }}
-          ref: main
-          path: ./actions
-
-      - id: asanatask
-        name: '[FRVR Action] Create Asana task'
-        uses: ./actions/.github/actions/createasanaticket
-        with:
-          game_name: ${{ needs.gather_game_data.outputs.game_name }}
-          game_branch: ${{ github.event.inputs.game_branch }}
-          deployed_filename: ${{ needs.build_facebook_instant.outputs.filename }}
-          frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
-          ticket_message: 'Play Link: ${{ needs.deploy_facebook_instant.outputs.deploy_url }}'
-          channel: 'Facebook Instant'
-          asana_check: ${{ github.event.inputs.asana_check }}
-          ASANA_PAT: ${{ secrets.ASANA_PAT }}
-    outputs:
-      task_url: ${{ steps.asanatask.outputs.task_url }}
-
   ## --- Update Masterdoc ---
   update_master_doc:
     name: Update Masterdoc
@@ -212,7 +171,7 @@ jobs:
     name: Notify slack
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [gather_game_data, build_facebook_instant, deploy_facebook_instant, create_asana_task]
+    needs: [gather_game_data, build_facebook_instant, deploy_facebook_instant]
     steps:
       - name: Checkout game repo
         uses: actions/checkout@v3
@@ -235,6 +194,6 @@ jobs:
           game_branch: ${{ github.event.inputs.game_branch }}
           frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
           channel: 'instant'
-          task_url: ${{ needs.create_asana_task.outputs.task_url }}
+          task_url: 'none'
           deploy_url: ${{ needs.deploy_facebook_instant.outputs.deploy_url }}
           binary_url: ${{ needs.build_facebook_instant.outputs.binary_url }}

--- a/.github/workflows/pipeline-google_play.yml
+++ b/.github/workflows/pipeline-google_play.yml
@@ -9,9 +9,6 @@ on:
       frvr_tools_branch:
         required: true
         type: string
-      asana_check:
-        required: true
-        type: string
       comment:
         required: true
         type: string
@@ -29,8 +26,6 @@ on:
       GCS_DEVOPS_BINARY_BUCKET_KEY:
         required: true
       GCS_SA_KEY:
-        required: true
-      ASANA_PAT:
         required: true
       GCS_MASTERDOC_SERVICE_ACCOUNT_KEY:
         required: true
@@ -100,7 +95,6 @@ jobs:
       build_json: ${{ steps.buildgoogleplay.outputs.build_json }}
       binary_url: ${{ steps.buildgoogleplay.outputs.binary_url }}
 
-
   # ## --- Deploy Google Play binary ---
   # deploy_google_play:
   #   name: Deploy Google Play
@@ -141,42 +135,6 @@ jobs:
   #         GCS_SA_KEY: ${{ secrets.GCS_SA_KEY }}
   #   outputs:
   #     deploy_url: ${{ steps.deploy_google_play.outputs.deploy_url }}
-
-  ## --- Create the Asana task ---
-  # create_asana_task:
-  #   name: Create Asana task
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 10
-  #   needs: [gather_game_data, build_google_play, deploy_google_play]
-  #   steps:
-  #     - name: Checkout game repo
-  #       uses: actions/checkout@v3
-  #       with:
-  #         path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
-  #         ref: ${{ github.event.inputs.game_branch }}
-
-  #     - name: Checkout private actions
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: frvraps/frvr-gh-workflows
-  #         token: ${{ secrets.GH_TOKEN }}
-  #         ref: main
-  #         path: ./actions
-
-  #     - id: asanatask
-  #       name: '[FRVR Action] Create Asana task'
-  #       uses: ./actions/.github/actions/createasanaticket
-  #       with:
-  #         game_name: ${{ needs.gather_game_data.outputs.game_name }}
-  #         game_branch: ${{ github.event.inputs.game_branch }}
-  #         deployed_filename: ${{ needs.build_google_play.outputs.filename }}
-  #         frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
-  #         ticket_message: 'Play Link: ${{ needs.deploy_google_play.outputs.deploy_url }}'
-  #         channel: 'Google Play Store'
-  #         asana_check: ${{ github.event.inputs.asana_check }}
-  #         ASANA_PAT: ${{ secrets.ASANA_PAT }}
-  #   outputs:
-  #     task_url: ${{ steps.asanatask.outputs.task_url }}
 
   # ## --- Update Masterdoc ---
   # update_master_doc:

--- a/.github/workflows/pipeline-samsung-galaxy.yml
+++ b/.github/workflows/pipeline-samsung-galaxy.yml
@@ -9,7 +9,6 @@ on:
       frvr_tools_branch:
         required: true
         type: string
-        type: string
       comment:
         required: true
         type: string

--- a/.github/workflows/pipeline-samsung-galaxy.yml
+++ b/.github/workflows/pipeline-samsung-galaxy.yml
@@ -9,8 +9,6 @@ on:
       frvr_tools_branch:
         required: true
         type: string
-      asana_check:
-        required: true
         type: string
       comment:
         required: true
@@ -29,8 +27,6 @@ on:
       GCS_DEVOPS_BINARY_BUCKET_KEY:
         required: true
       GCS_SA_KEY:
-        required: true
-      ASANA_PAT:
         required: true
       GCS_MASTERDOC_SERVICE_ACCOUNT_KEY:
         required: true
@@ -141,42 +137,6 @@ jobs:
           GCS_SA_KEY: ${{ secrets.GCS_SA_KEY }}
     outputs:
       deploy_url: ${{ steps.deploy_samsung_galaxy.outputs.deploy_url }}
-
-  ## --- Create the Asana task ---
-  # create_asana_task:
-  #   name: Create Asana task
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 10
-  #   needs: [gather_game_data, build_samsung_galaxy, deploy_samsung_galaxy]
-  #   steps:
-  #     - name: Checkout game repo
-  #       uses: actions/checkout@v3
-  #       with:
-  #         path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
-  #         ref: ${{ github.event.inputs.game_branch }}
-
-  #     - name: Checkout private actions
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: frvraps/frvr-gh-workflows
-  #         token: ${{ secrets.GH_TOKEN }}
-  #         ref: main
-  #         path: ./actions
-
-  #     - id: asanatask
-  #       name: '[FRVR Action] Create Asana task'
-  #       uses: ./actions/.github/actions/createasanaticket
-  #       with:
-  #         game_name: ${{ needs.gather_game_data.outputs.game_name }}
-  #         game_branch: ${{ github.event.inputs.game_branch }}
-  #         deployed_filename: ${{ needs.build__samsung_galaxy.outputs.filename }}
-  #         frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
-  #         ticket_message: 'Play Link: ${{ needs.deploy__samsung_galaxy.outputs.deploy_url }}'
-  #         channel: 'Samsung Galaxy Store'
-  #         asana_check: ${{ github.event.inputs.asana_check }}
-  #         ASANA_PAT: ${{ secrets.ASANA_PAT }}
-  #   outputs:
-  #     task_url: ${{ steps.asanatask.outputs.task_url }}
 
   ## --- Update Masterdoc ---
   update_master_doc:

--- a/.github/workflows/pipeline-sip.yml
+++ b/.github/workflows/pipeline-sip.yml
@@ -9,9 +9,6 @@ on:
       frvr_tools_branch:
         required: true
         type: string
-      asana_check:
-        required: true
-        type: string
     secrets:
       CR_PAT:
         required: true
@@ -26,8 +23,6 @@ on:
       GCS_DEVOPS_BINARY_BUCKET_KEY:
         required: true
       GCS_SA_KEY:
-        required: true
-      ASANA_PAT:
         required: true
       GCS_MASTERDOC_SERVICE_ACCOUNT_KEY:
         required: true
@@ -132,42 +127,6 @@ jobs:
     outputs:
       deploy_url: ${{ steps.deploy_sip.outputs.deploy_url }}
 
-  # ## --- Create the Asana task ---
-  create_asana_task:
-    name: Create Asana task
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: [gather_game_data, build_sip, deploy_sip]
-    steps:
-      - name: Checkout game repo
-        uses: actions/checkout@v3
-        with:
-          path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
-          ref: ${{ github.event.inputs.game_branch }}
-
-      - name: Checkout private actions
-        uses: actions/checkout@v3
-        with:
-          repository: frvraps/frvr-gh-workflows
-          token: ${{ secrets.GH_TOKEN }}
-          ref: main
-          path: ./actions
-
-      - id: asanatask
-        name: '[FRVR Action] Create Asana task'
-        uses: ./actions/.github/actions/createasanaticket
-        with:
-          game_name: ${{ needs.gather_game_data.outputs.game_name }}
-          game_branch: ${{ github.event.inputs.game_branch }}
-          deployed_filename: ${{ needs.build_sip.outputs.filename }}
-          frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
-          ticket_message: 'Deploy Link: ${{ needs.deploy_sip.outputs.deploy_url }}'
-          channel: 'sip'
-          asana_check: ${{ github.event.inputs.asana_check }}
-          ASANA_PAT: ${{ secrets.ASANA_PAT }}
-    outputs:
-      task_url: ${{ steps.asanatask.outputs.task_url }}
-
   ## --- Update Masterdoc ---
   update_master_doc:
     name: Update Masterdoc
@@ -206,7 +165,7 @@ jobs:
     name: Notify slack
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [gather_game_data, build_sip, deploy_sip, create_asana_task]
+    needs: [gather_game_data, build_sip, deploy_sip]
     steps:
       - name: Checkout game repo
         uses: actions/checkout@v3
@@ -230,6 +189,6 @@ jobs:
           frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
           channel: 'samsung-instant-play'
           deploy_url: ${{ needs.deploy_sip.outputs.deploy_url }}
-          task_url: ${{ needs.create_asana_task.outputs.task_url }}
+          task_url: ''
           binary_url: ${{ needs.build_sip.outputs.binary_url }}
 

--- a/.github/workflows/pipeline-web.yml
+++ b/.github/workflows/pipeline-web.yml
@@ -3,9 +3,6 @@ name: "[Pipeline] Build and deploy Web"
 on:
   workflow_call:
     inputs:
-      asana_check:
-        required: true
-        type: string
       fst_image:
         required: true
         type: string
@@ -32,8 +29,6 @@ on:
       GCS_DEVOPS_BINARY_BUCKET_KEY:
         required: true
       GCS_SA_KEY:
-        required: true
-      ASANA_PAT:
         required: true
       GCS_MASTERDOC_SERVICE_ACCOUNT_KEY:
         required: true
@@ -154,42 +149,6 @@ jobs:
     outputs:
       deploy_url: ${{ steps.deployweb.outputs.deploy_url }}
 
-  ## --- Create the Asana task ---
-  create_asana_task:
-    name: Create Asana task
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: [gather_game_data, build_web, deploy_web]
-    steps:
-      - name: Checkout game repo
-        uses: actions/checkout@v3
-        with:
-          path: frvr/game-${{ needs.gather_game_data.outputs.game_name }}
-          ref: ${{ github.event.inputs.game_branch }}
-
-      - name: Checkout private actions
-        uses: actions/checkout@v3
-        with:
-          repository: frvraps/frvr-gh-workflows
-          token: ${{ secrets.GH_TOKEN }}
-          ref: main
-          path: ./actions
-
-      - id: asanatask
-        name: '[FRVR Action] Create Asana task'
-        uses: ./actions/.github/actions/createasanaticket
-        with:
-          game_name: ${{ needs.gather_game_data.outputs.game_name }}
-          game_branch: ${{ github.event.inputs.game_branch }}
-          deployed_filename: ${{ needs.build_web.outputs.filename }}
-          frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
-          ticket_message: "Beta Web deploy link: ${{ needs.deploy_web.outputs.deploy_url }}"
-          channel: 'web'
-          asana_check: ${{ github.event.inputs.asana_check }}
-          ASANA_PAT: ${{ secrets.ASANA_PAT }}
-    outputs:
-      task_url: ${{ steps.asanatask.outputs.task_url }}
-
   ## --- Update Masterdoc ---
   update_master_doc:
     name: Update Masterdoc
@@ -228,7 +187,7 @@ jobs:
     name: Notify slack
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [gather_game_data, build_web, deploy_web, create_asana_task]
+    needs: [gather_game_data, build_web, deploy_web]
     steps:
       - name: Checkout game repo
         uses: actions/checkout@v3
@@ -252,5 +211,5 @@ jobs:
           frvr_tools_branch: ${{ github.event.inputs.frvr_tools_branch }}
           channel: 'web'
           deploy_url: ${{ needs.deploy_web.outputs.deploy_url }}
-          task_url: ${{ needs.create_asana_task.outputs.task_url }}
+          task_url: ''
           binary_url: ${{ needs.build_web.outputs.binary_url }}


### PR DESCRIPTION
# Type of PR
[ ] Bug Fix
[ ] New Feature
[ X ] Other (maintenance)

# References
[XS-487](https://frvr.atlassian.net/browse/XS-487)

# What problem does this PR address
Asana is no longer being used by QA, so we no longer want to create tickets for it.

# How does this PR addresses the problem
This PR removes the `create_asana_task` job from each of the channel workflows, as well as its related configuration.

# Implementation notes
None

# Platforms/Channels
All
