### PR TITLE
fix(ENG-584): tweak default CI

### DIFF
--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: main
+          ref: ENG-584
           path: ./actions
 
       - id: buildweb

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: main
+          ref: ENG-584
           path: ./actions
 
       - id: deployweb

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -1,4 +1,4 @@
-name: "[CI/CD] Default FRVR CI"
+name: "[CI/CD] Default XS Game CI"
 
 on:
   workflow_call:
@@ -74,7 +74,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: ENG-584
+          ref: main
           path: ./actions
 
       - id: buildweb
@@ -109,7 +109,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: ENG-584
+          ref: main
           path: ./actions
 
       - id: deployweb

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -98,11 +98,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [gather_game_data, build_web]
-    container:
-      image: ${{ inputs.fst_image }}:latest
-      credentials:
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.CR_PAT }}
     steps:
       - name: Checkout game repo
         uses: actions/checkout@v3


### PR DESCRIPTION
# Type of PR
[ X ] Bug Fix
[ ] New Feature
[ ] Other

# References
[ENG-584](https://app.clickup.com/t/36255767/ENG-584)

# What problem does this PR address
Default CI (web) started exhibiting a weird issue, with undetermined cause (since nothing was changed on the process, at least from FRVR side) when deploying web the CI build to beta.

# How does this PR addresses the problem
Updates the web build and deploy actions.
Web deploys now copy directly to beta.frvr.com without using `fst deploy-beta`.
Web deploys no longer need to use the fst docker.

# Implementation notes
Companion PR in frvraps/frvr-gh-workflows [here](https://github.com/frvraps/frvr-gh-workflows/pull/17)

# Platforms/Channels
Web

# What was tested
Several runs default CI runs with `game-portaltests`
