### PR TITLE
PNX-958 + PNX-951 + PNX-950: Generate, collect and pipe game run info to QA Service

### DIFF
--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -133,7 +133,7 @@ jobs:
 
   ## --- Screenshot sanity ---
   screenshot_sanity:
-    name: Deploy web version
+    name: Screenshot sanity
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [gather_game_data, build_web]
@@ -157,7 +157,7 @@ jobs:
           path: ./actions
 
       - id: screenshottests
-        name: '[FRVR Action] Deploy action for WEB'
+        name: '[FRVR Action] Perfom screenshot sanity'
         uses: ./actions/.github/actions/runscreenshottests
         with:
           game_name: ${{ needs.gather_game_data.outputs.game_name }}

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: main
+          ref: PNX-958-add-screenshot-tests-action
           path: ./actions
 
       - id: screenshottests

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -226,7 +226,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
           ec2-image-id: 'ami-0961bcb2849df07df'
-          ec2-instance-type: c5.large
+          ec2-instance-type: c5.2xlarge
           subnet-id: subnet-3b45ac52
           security-group-id: sg-0661cd8e1b647d28f
           label: ${{ matrix.label }}
@@ -289,13 +289,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      # - name: Stop EC2 runner
-      #   uses: RuiGamitoFRVR/ec2-github-runner_forked@main
-      #   with:
-      #     mode: stop
-      #     github-token: ${{ secrets.GH_TOKEN }}
-      #     label: ${{ needs.start_runner.outputs.label }}
-      #     ec2-instance-id: ${{ needs.start_runner.outputs.ec2-instance-id }}          
+      - name: Stop EC2 runner
+        uses: RuiGamitoFRVR/ec2-github-runner_forked@main
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_TOKEN }}
+          label: ${{ needs.start_runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start_runner.outputs.ec2-instance-id }}          
 
   ## --- Run GUI Automated tests on WEB ---
   run_web_gui_automated_tests:

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -46,11 +46,13 @@ jobs:
         uses: ./actions/.github/actions/getmetadata
         with:
           channel: 'web'
-          frvr_tools_branch: 'latest'
+          frvr_tools_branch: ${{ vars.OFFICIAL_FRVR_TOOLS_BRANCH }}
+          collect_kpis: 'true'
     outputs:
       fst_version: ${{ steps.metadata.outputs.fst_version }}
       game_name: ${{ steps.metadata.outputs.game_name }}
-      deploy_msg: ${{ steps.metadata.outputs.deploy_msg }}  
+      deploy_msg: ${{ steps.metadata.outputs.deploy_msg }}
+      game_run_id: ${{ steps.metadata.outputs.game_run_id }}
 
   ## --- BUILD TO WEB ---
   build_web:

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -120,9 +120,9 @@ jobs:
       build_json: ${{ steps.buildweb.outputs.build_json }}
       build_size: ${{ steps.buildweb.outputs.build_size }}
 
-  ## --- BUILD TO WEB ---
+  ## --- BUILD TO WEB (no CP for 'fsx check') ---
   build_web_for_check:
-    name: Build web version
+    name: Build web version (for fsx check)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [gather_game_data]

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -255,4 +255,4 @@ jobs:
         with:
           game_run_id: ${{ needs.gather_game_data.outputs.game_run_id }}
           qa_service: ${{ inputs.QA_SERVICE }}
-          success: ${{ needs.run_web_gui_automated_tests.result || needs.screenshot_sanity.result }}
+          success: ${{ needs.run_web_gui_automated_tests.result && needs.screenshot_sanity.result }}

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -228,6 +228,8 @@ jobs:
           QA_SERVICE_KEY: ${{ secrets.QA_SERVICE_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
+          GCS_SA_KEY: ${{ secrets.GCS_SA_KEY }}
+          GCS_PROJECT: ${{ secrets.GCS_PROJECT }}
 
   stop_runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: PNX-958-add-screenshot-tests-action
+          ref: main
           path: ./actions
 
       - id: metadata
@@ -100,7 +100,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: PNX-958-add-screenshot-tests-action
+          ref: main
           path: ./actions
 
       - id: buildweb
@@ -142,7 +142,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: PNX-958-add-screenshot-tests-action
+          ref: main
           path: ./actions
 
       - id: buildweb
@@ -180,7 +180,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: PNX-958-add-screenshot-tests-action
+          ref: main
           path: ./actions
 
       - id: deployweb
@@ -221,7 +221,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: RuiGamitoFRVR/ec2-github-runner_forked@feat/add_custom_runner_labels
+        uses: RuiGamitoFRVR/ec2-github-runner_forked@main
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -254,7 +254,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: PNX-958-add-screenshot-tests-action
+          ref: main
           path: ./actions
 
       - id: screenshottests
@@ -335,7 +335,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: PNX-958-add-screenshot-tests-action
+          ref: main
           path: ./actions
 
       - name: '[FRVR Action] Web GUI tests'
@@ -370,7 +370,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: PNX-958-add-screenshot-tests-action
+          ref: main
           path: ./actions
 
       - id: patch_completion

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -31,6 +31,8 @@ on:
         required: true
       GH_PACKAGE_REGISTRY_PAT:
         required: true
+      QA_SERVICE_KEY:
+        required: true
 
 jobs:
   ## --- GET GAME METADATA ---
@@ -59,6 +61,7 @@ jobs:
           collect_kpis: 'true'
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           QA_SERVICE: ${{ inputs.QA_SERVICE }}
+          QA_SERVICE_KEY: ${{ secrets.QA_SERVICE_KEY }}
     outputs:
       fst_version: ${{ steps.metadata.outputs.fst_version }}
       game_name: ${{ steps.metadata.outputs.game_name }}
@@ -176,6 +179,7 @@ jobs:
           bucket_uri: ${{ inputs.BUCKET_URI }}
           bucket_uri_prefix: ${{ inputs.BUCKET_URI_PREFIX }}
           qa_service: ${{ inputs.QA_SERVICE }}
+          QA_SERVICE_KEY: ${{ secrets.QA_SERVICE_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
 
@@ -223,6 +227,7 @@ jobs:
           game_run_id: ${{ needs.gather_game_data.outputs.game_run_id }}
           collect_kpis: 'true'
           qa_service: ${{ inputs.QA_SERVICE }}
+          QA_SERVICE_KEY: ${{ secrets.QA_SERVICE_KEY }}
         env:
           TEST_URL: ${{ needs.deploy_web.outputs.deploy_url }}
           HEADLESS: true
@@ -255,4 +260,5 @@ jobs:
         with:
           game_run_id: ${{ needs.gather_game_data.outputs.game_run_id }}
           qa_service: ${{ inputs.QA_SERVICE }}
+          QA_SERVICE_KEY: ${{ secrets.QA_SERVICE_KEY }}
           success: ${{ needs.run_web_gui_automated_tests.result && needs.screenshot_sanity.result }}

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -136,7 +136,7 @@ jobs:
     name: Screenshot sanity
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [gather_game_data, build_web]
+    needs: [gather_game_data, build_web, deploy_web]
     # container:
     #   image: ${{ inputs.fst_image }}:latest
     #   credentials:
@@ -163,6 +163,7 @@ jobs:
           game_name: ${{ needs.gather_game_data.outputs.game_name }}
           game_branch: ${{ github.event.inputs.game_branch }}
           build_identifier: ${{ needs.build_web.outputs.filename }}
+          game_url: ${{ needs.deploy_web.outputs.deploy_url }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           is_ci: true
           GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -152,17 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [gather_game_data, build_web, deploy_web]
-    # container:
-    #   image: ${{ inputs.fst_image }}:latest
-    #   credentials:
-    #     username: ${{ github.repository_owner }}
-    #     password: ${{ secrets.CR_PAT }}
     steps:
-      # - name: Checkout game repo
-      #   uses: actions/checkout@v3
-      #   with:
-      #     ref: ${{ github.event.inputs.game_branch }}
-
       - name: Checkout private actions
         uses: actions/checkout@v3
         with:
@@ -191,7 +181,7 @@ jobs:
     # outputs:
     #   deploy_url: ${{ steps.deployweb.outputs.deploy_url }}
 
-  # --- Run GUI Automated tests on WEB ---
+  ## --- Run GUI Automated tests on WEB ---
   run_web_gui_automated_tests:
     name: GUI automated tests on web
     runs-on: ubuntu-latest
@@ -242,3 +232,32 @@ jobs:
 
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3
+
+  ## --- PATCH CI run completion to QA Services ---
+  signal_run_completion:
+    name: Patch completion to QA Service
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [gather_game_data, run_web_gui_automated_tests, screenshot_sanity]
+    if: always()
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.game_branch }}
+
+      - name: Checkout private actions
+        uses: actions/checkout@v3
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: PNX-958-add-screenshot-tests-action
+          path: ./actions
+
+      - id: patch_completion
+        name: '[FRVR Action] Deploy action for WEB'
+        uses: ./actions/.github/actions/patchgameruncompletion
+        with:
+          game_run_id: ${{ needs.gather_game_data.outputs.game_run_id }}
+          qa_service: ${{ inputs.QA_SERVICE }}
+          success: ${{ needs.run_web_gui_automated_tests.result || needs.screenshot_sanity.result }}

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -178,8 +178,6 @@ jobs:
           qa_service: ${{ inputs.QA_SERVICE }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
-    # outputs:
-    #   deploy_url: ${{ steps.deployweb.outputs.deploy_url }}
 
   ## --- Run GUI Automated tests on WEB ---
   run_web_gui_automated_tests:
@@ -229,9 +227,6 @@ jobs:
           TEST_URL: ${{ needs.deploy_web.outputs.deploy_url }}
           HEADLESS: true
           TESTS_PATH: ${{ github.workspace }}/game/tests
-
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
 
   ## --- PATCH CI run completion to QA Services ---
   signal_run_completion:

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -9,6 +9,9 @@ on:
       automation_image:
         required: true
         type: string
+      game_sha:
+        required: true
+        type: string
       QA_SERVICE:
         required: false
         type: string
@@ -32,6 +35,12 @@ on:
       GH_PACKAGE_REGISTRY_PAT:
         required: true
       QA_SERVICE_KEY:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_REGION:
         required: true
 
 jobs:
@@ -149,12 +158,48 @@ jobs:
     outputs:
       deploy_url: ${{ steps.deployweb.outputs.deploy_url }}
 
-  ## --- Screenshot sanity ---
+  ## --- START AWS VM ---
+  start_runner:
+    name: Bootup the VMs
+    runs-on: ubuntu-latest
+    needs: [gather_game_data]
+    timeout-minutes: 5
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: RuiGamitoFRVR/ec2-github-runner_forked@feat/add_custom_runner_labels
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_TOKEN }}
+          ec2-image-id: 'ami-0961bcb2849df07df'
+          ec2-instance-type: c5.2xlarge
+          subnet-id: subnet-3b45ac52
+          security-group-id: sg-0661cd8e1b647d28f
+          label: ${{ matrix.label }}
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "${{ matrix.label }}"},
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
+            ]
+          runner-labels: 'game_ci_${{ inputs.game_sha }}'
+
+  ## --- SCREENSHOT SANITY ---
   screenshot_sanity:
     name: Screenshot sanity
-    runs-on: ubuntu-latest
+    runs-on: game_ci_${{ inputs.game_sha }}
     timeout-minutes: 15
-    needs: [gather_game_data, build_web, deploy_web]
+    needs: [gather_game_data, build_web, deploy_web, start_runner]
     steps:
       - name: Checkout private actions
         uses: actions/checkout@v3
@@ -166,11 +211,12 @@ jobs:
 
       - id: screenshottests
         name: '[FRVR Action] Perfom screenshot sanity'
-        uses: ./actions/.github/actions/runscreenshottests
+        uses: ./actions/.github/actions/runscreenshottests_aws
         with:
           game_name: ${{ needs.gather_game_data.outputs.game_name }}
           game_branch: ${{ github.event.inputs.game_branch }}
           game_url: ${{ needs.deploy_web.outputs.deploy_url }}
+          build_identifier: ${{ needs.build_web.outputs.filename }}
           game_run_id: ${{ needs.gather_game_data.outputs.game_run_id }}
           collect_kpis: 'true'
           build_size: ${{ needs.build_web.outputs.build_size}}
@@ -182,6 +228,29 @@ jobs:
           QA_SERVICE_KEY: ${{ secrets.QA_SERVICE_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
+
+  stop_runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start_runner
+      - screenshot_sanity
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Stop EC2 runner
+        uses: RuiGamitoFRVR/ec2-github-runner_forked@main
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_TOKEN }}
+          label: ${{ needs.start_runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start_runner.outputs.ec2-instance-id }}          
 
   ## --- Run GUI Automated tests on WEB ---
   run_web_gui_automated_tests:

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -14,7 +14,10 @@ on:
         type: string
       BUCKET_URI:
         required: false
-        type: string  
+        type: string
+      BUCKET_URI_PREFIX:
+        required: false
+        type: string
     secrets:
       CR_PAT:
         required: true
@@ -174,7 +177,6 @@ jobs:
         with:
           game_name: ${{ needs.gather_game_data.outputs.game_name }}
           game_branch: ${{ github.event.inputs.game_branch }}
-          build_identifier: ${{ needs.build_web.outputs.filename }}
           game_url: ${{ needs.deploy_web.outputs.deploy_url }}
           game_run_id: ${{ needs.gather_game_data.outputs.game_run_id }}
           collect_kpis: 'true'
@@ -182,11 +184,10 @@ jobs:
           storage_name: ${{ needs.gather_game_data.outputs.storage_name }}
           is_ci: true
           bucket_uri: ${{ inputs.BUCKET_URI }}
+          bucket_uri_prefix: ${{ inputs.BUCKET_URI_PREFIX }}
           qa_service: ${{ inputs.QA_SERVICE }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
-          GCS_SA_KEY: ${{ secrets.GCS_SA_KEY }}
-          GCS_PROJECT: ${{ secrets.GCS_PROJECT }}
     # outputs:
     #   deploy_url: ${{ steps.deployweb.outputs.deploy_url }}
 
@@ -194,7 +195,7 @@ jobs:
   run_web_gui_automated_tests:
     name: GUI automated tests on web
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     needs: [gather_game_data, build_web, deploy_web]
     defaults:
       run:
@@ -231,7 +232,13 @@ jobs:
         with:
           game_name: ${{ needs.gather_game_data.outputs.game_name }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          game_run_id: ${{ needs.gather_game_data.outputs.game_run_id }}
+          collect_kpis: 'true'
+          qa_service: ${{ inputs.QA_SERVICE }}
         env:
           TEST_URL: ${{ needs.deploy_web.outputs.deploy_url }}
           HEADLESS: true
           TESTS_PATH: ${{ github.workspace }}/game/tests
+
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -183,7 +183,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
           ec2-image-id: 'ami-0961bcb2849df07df'
-          ec2-instance-type: c5.2xlarge
+          ec2-instance-type: c5.large
           subnet-id: subnet-3b45ac52
           security-group-id: sg-0661cd8e1b647d28f
           label: ${{ matrix.label }}
@@ -246,13 +246,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Stop EC2 runner
-        uses: RuiGamitoFRVR/ec2-github-runner_forked@main
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_TOKEN }}
-          label: ${{ needs.start_runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start_runner.outputs.ec2-instance-id }}          
+      # - name: Stop EC2 runner
+      #   uses: RuiGamitoFRVR/ec2-github-runner_forked@main
+      #   with:
+      #     mode: stop
+      #     github-token: ${{ secrets.GH_TOKEN }}
+      #     label: ${{ needs.start_runner.outputs.label }}
+      #     ec2-instance-id: ${{ needs.start_runner.outputs.ec2-instance-id }}          
 
   ## --- Run GUI Automated tests on WEB ---
   run_web_gui_automated_tests:

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -9,6 +9,12 @@ on:
       automation_image:
         required: true
         type: string
+      QA_SERVICE:
+        required: false
+        type: string
+      BUCKET_URI:
+        required: false
+        type: string  
     secrets:
       CR_PAT:
         required: true
@@ -48,11 +54,14 @@ jobs:
           channel: 'web'
           frvr_tools_branch: ${{ vars.OFFICIAL_FRVR_TOOLS_BRANCH }}
           collect_kpis: 'true'
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          QA_SERVICE: ${{ inputs.QA_SERVICE }}
     outputs:
       fst_version: ${{ steps.metadata.outputs.fst_version }}
       game_name: ${{ steps.metadata.outputs.game_name }}
       deploy_msg: ${{ steps.metadata.outputs.deploy_msg }}
       game_run_id: ${{ steps.metadata.outputs.game_run_id }}
+      storage_name: ${{ steps.metadata.outputs.storage_name }}
 
   ## --- BUILD TO WEB ---
   build_web:
@@ -94,6 +103,7 @@ jobs:
     outputs:
       filename: ${{ steps.buildweb.outputs.filename }}
       build_json: ${{ steps.buildweb.outputs.build_json }}
+      build_size: ${{ steps.buildweb.outputs.build_size }}
 
   ## --- DEPLOY TO WEB ---
   deploy_web:
@@ -166,8 +176,14 @@ jobs:
           game_branch: ${{ github.event.inputs.game_branch }}
           build_identifier: ${{ needs.build_web.outputs.filename }}
           game_url: ${{ needs.deploy_web.outputs.deploy_url }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          game_run_id: ${{ needs.gather_game_data.outputs.game_run_id }}
+          collect_kpis: 'true'
+          build_size: ${{ needs.build_web.outputs.build_size}}
+          storage_name: ${{ needs.gather_game_data.outputs.storage_name }}
           is_ci: true
+          bucket_uri: ${{ inputs.BUCKET_URI }}
+          qa_service: ${{ inputs.QA_SERVICE }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
           GCS_SA_KEY: ${{ secrets.GCS_SA_KEY }}
           GCS_PROJECT: ${{ secrets.GCS_PROJECT }}

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: main
+          ref: PNX-958-add-screenshot-tests-action
           path: ./actions
 
       - id: metadata
@@ -76,7 +76,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: main
+          ref: PNX-958-add-screenshot-tests-action
           path: ./actions
 
       - id: buildweb
@@ -112,7 +112,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: main
+          ref: PNX-958-add-screenshot-tests-action
           path: ./actions
 
       - id: deployweb
@@ -207,7 +207,7 @@ jobs:
         with:
           repository: frvraps/frvr-gh-workflows
           token: ${{ secrets.GH_TOKEN }}
-          ref: main
+          ref: PNX-958-add-screenshot-tests-action
           path: ./actions
 
       - name: '[FRVR Action] Web GUI tests'

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -131,6 +131,46 @@ jobs:
     outputs:
       deploy_url: ${{ steps.deployweb.outputs.deploy_url }}
 
+  ## --- Screenshot sanity ---
+  screenshot_sanity:
+    name: Deploy web version
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [gather_game_data, build_web]
+    container:
+      image: ${{ inputs.fst_image }}:latest
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.game_branch }}
+
+      - name: Checkout private actions
+        uses: actions/checkout@v3
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: main
+          path: ./actions
+
+      - id: screenshottests
+        name: '[FRVR Action] Deploy action for WEB'
+        uses: ./actions/.github/actions/runscreenshottests
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          game_branch: ${{ github.event.inputs.game_branch }}
+          build_identifier: ${{ needs.build_web.outputs.filename }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          is_ci: true
+          GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
+          GCS_SA_KEY: ${{ secrets.GCS_SA_KEY }}
+          GCS_PROJECT: ${{ secrets.GCS_PROJECT }}
+    # outputs:
+    #   deploy_url: ${{ steps.deployweb.outputs.deploy_url }}
+
   # --- Run GUI Automated tests on WEB ---
   run_web_gui_automated_tests:
     name: GUI automated tests on web

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -255,7 +255,7 @@ jobs:
           path: ./actions
 
       - id: patch_completion
-        name: '[FRVR Action] Deploy action for WEB'
+        name: '[FRVR Action] Signal run completion to QA Service'
         uses: ./actions/.github/actions/patchgameruncompletion
         with:
           game_run_id: ${{ needs.gather_game_data.outputs.game_run_id }}

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -244,6 +244,11 @@ jobs:
     timeout-minutes: 15
     needs: [gather_game_data, build_web_for_check, start_runner]
     steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.game_branch }}
+          
       - name: Checkout private actions
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -137,16 +137,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [gather_game_data, build_web]
-    container:
-      image: ${{ inputs.fst_image }}:latest
-      credentials:
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.CR_PAT }}
+    # container:
+    #   image: ${{ inputs.fst_image }}:latest
+    #   credentials:
+    #     username: ${{ github.repository_owner }}
+    #     password: ${{ secrets.CR_PAT }}
     steps:
-      - name: Checkout game repo
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.game_branch }}
+      # - name: Checkout game repo
+      #   uses: actions/checkout@v3
+      #   with:
+      #     ref: ${{ github.event.inputs.game_branch }}
 
       - name: Checkout private actions
         uses: actions/checkout@v3

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -120,6 +120,49 @@ jobs:
       build_json: ${{ steps.buildweb.outputs.build_json }}
       build_size: ${{ steps.buildweb.outputs.build_size }}
 
+  ## --- BUILD TO WEB ---
+  build_web_for_check:
+    name: Build web version
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [gather_game_data]
+    container:
+      image: ${{ inputs.fst_image }}:latest
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+    steps:
+      - name: Checkout game repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.game_branch }}
+
+      - name: Checkout private actions
+        uses: actions/checkout@v3
+        with:
+          repository: frvraps/frvr-gh-workflows
+          token: ${{ secrets.GH_TOKEN }}
+          ref: PNX-958-add-screenshot-tests-action
+          path: ./actions
+
+      - id: buildweb
+        name: '[FRVR Action] Build action for WEB'
+        uses: ./actions/.github/actions/buildweb
+        with:
+          game_name: ${{ needs.gather_game_data.outputs.game_name }}
+          game_branch: ${{ github.event.inputs.game_branch }}
+          is_ci: true
+          custom_params: --no-cp
+          frvr_internal_branch: ${{ github.event.inputs.frvr_internal_branch }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GCS_DEVOPS_BINARY_BUCKET_KEY: ${{ secrets.GCS_DEVOPS_BINARY_BUCKET_KEY }}
+          GCS_SA_KEY: ${{ secrets.GCS_SA_KEY }}
+        
+    outputs:
+      filename: ${{ steps.buildweb.outputs.filename }}
+      build_json: ${{ steps.buildweb.outputs.build_json }}
+      build_size: ${{ steps.buildweb.outputs.build_size }}
+
   ## --- DEPLOY TO WEB ---
   deploy_web:
     name: Deploy web version
@@ -199,7 +242,7 @@ jobs:
     name: Screenshot sanity
     runs-on: game_ci_${{ inputs.game_sha }}
     timeout-minutes: 15
-    needs: [gather_game_data, build_web, deploy_web, start_runner]
+    needs: [gather_game_data, build_web_for_check, start_runner]
     steps:
       - name: Checkout private actions
         uses: actions/checkout@v3
@@ -216,10 +259,10 @@ jobs:
           game_name: ${{ needs.gather_game_data.outputs.game_name }}
           game_branch: ${{ github.event.inputs.game_branch }}
           game_url: ${{ needs.deploy_web.outputs.deploy_url }}
-          build_identifier: ${{ needs.build_web.outputs.filename }}
+          build_identifier: ${{ needs.build_web_for_check.outputs.filename }}
           game_run_id: ${{ needs.gather_game_data.outputs.game_run_id }}
           collect_kpis: 'true'
-          build_size: ${{ needs.build_web.outputs.build_size}}
+          build_size: ${{ needs.build_web_for_check.outputs.build_size}}
           storage_name: ${{ needs.gather_game_data.outputs.storage_name }}
           is_ci: true
           bucket_uri: ${{ inputs.BUCKET_URI }}


### PR DESCRIPTION
# Type of PR
[ ] Bug Fix
[ X ] New Feature
[ ] Other

# References
- [PNX-958](https://frvr.atlassian.net/browse/PNX-958)
- [PNX-951](https://frvr.atlassian.net/browse/PNX-951)
- [PNX-950](https://frvr.atlassian.net/browse/PNX-950)

- [frvr-gh-worlkflows PR](https://github.com/frvraps/frvr-gh-workflows/pull/18)

# What problem does this PR address
We want to collect KPI's, screenshot comparison results and web gui test results on game CI runs, and pipe everything to the QA Service.

UPDATE:
It has been decided that in order to have stable game KPI collections, we also need to run the screenshot sanity checks on the AWS runners, like we're doing for Engine runs. For this reason, there have been quite a few updates to this PR.

# How does this PR addresses the problem
This PR heavily tweaks the default CI public workflow, adding all necessary inputs and params, changing some dependencies and adding a new job.

# Implementation notes
N/A

# Platforms/Channels
Web

# What was tested
Copious amount of runs with `game-cave` and `game-basketball` using game branch `PNX-958`.
